### PR TITLE
Fix YAML loading bug for pyyaml versions earlier than 5.1

### DIFF
--- a/python/tree/__init__.py
+++ b/python/tree/__init__.py
@@ -18,7 +18,10 @@ NAME = 'tree'
 
 # Loads config
 with open(os.path.dirname(__file__) + '/etc/{0}.cfg'.format(NAME)) as ff:
-    config = yaml.load(ff, Loader=yaml.FullLoader)
+    try:
+        config = yaml.load(ff, Loader=yaml.FullLoader)
 
+    except AttributeError:
+        config = yaml.load(fp)
 
 __version__ = '2.15.6dev'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pyyaml
+pyyaml>=5.1
 pygments
 configparser>=3.5.0


### PR DESCRIPTION
See https://github.com/yaml/pyyaml/issues/265

`yaml.load(..., Loader=yaml.FullLoader)` fails for pyyaml versions earlier than 5.1. For those who have yet to update to pyyaml 5.1, this means the entire `tree` product cannot be used. 

Some of us (I won't name names) have resorted to checking out their own versions of the tree product so they can run their pipelines. 

This PR puts in a try/except so that pyyaml versions earlier than 5.1 won't fail, and makes >=5.1 an explicit requirement for pyyaml in the requirements.txt