### PR TITLE
adds support for preserving original os environ during replant

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ This document records the main changes to the tree code.
 - Added new sdss5 paths for apogee
 - Changed sdss5 paths for apogee from sdss4 to handle ``healpix`` grouping and simplified kwargs with special functions
 - Updating the code to write out old sdss_paths.ini file.
+- Added ``preserve_envvars`` options to ``replant_tree`` to preserve users original environment variables
 
 3.0.6 (2020-09-07)
 ------------------

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -41,7 +41,8 @@ except ModuleNotFoundError:
 # ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.napoleon', 'sphinx.ext.autosummary',
               'sphinx.ext.todo', 'sphinx.ext.viewcode', 'sphinx.ext.mathjax',
-              'sphinx.ext.intersphinx', 'tree.misc.docutree', 'recommonmark', 'sphinxarg.ext']
+              'sphinx.ext.intersphinx', 'tree.misc.docutree', 'recommonmark', 'sphinxarg.ext',
+              'sphinx_issues']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -83,6 +84,8 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
 default_role = 'py:obj'
+
+issues_github_path = "sdss/tree"
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
 # add_function_parentheses = True

--- a/docs/sphinx/config.rst
+++ b/docs/sphinx/config.rst
@@ -1,6 +1,9 @@
 
 .. _config:
 
+Available Tree configurations
+=============================
+
 Tree configurations
 -------------------
 

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -9,15 +9,18 @@
 
 This is the Sphinx documentation for the Python product tree
 
-Introduction
-------------
+Contents
+--------
 
-* :doc:`What's new in tree? <CHANGELOG>`
-* :doc:`Installation of python package <installation>`
-* :doc:`Introduction to the Tree <intro>`
-* :doc:`Tree environment configuration <config>`
-* :doc:`Setting up the Tree in your local enviroment <tree_setup>`
-* :doc:`Adding a new path into the Tree <paths>`
+.. toctree::
+  :maxdepth: 1
+
+  Installation of python package <installation>
+  Introduction to the Tree <intro>
+  Available configurations for the Tree <config>
+  Setting up the Tree in your local environment <tree_setup>
+  Adding a new path in the Tree <paths>
+
 
 Reference
 ---------
@@ -26,6 +29,9 @@ Reference
    :maxdepth: 1
 
    api
+   CHANGELOG
+   usage
+   tree_envs
 
 
 

--- a/docs/sphinx/intro.rst
+++ b/docs/sphinx/intro.rst
@@ -2,97 +2,146 @@
 .. _intro:
 
 Introduction to tree
-===============================
+====================
 
 The SAS Tree defines the directory structure in which all SDSS data files live.  The SAS tree product helps set up all the
 SDSS environment variables you need to run SDSS products. The list of currrently available environment variables can be found
 :ref:`here <config>`.
 
-This product provides a Python package version of the tree.  See the :ref:`installation <install>` instructions.
-To use the tree, and set up its environment variables, you may simply import it::
-
-    # import the tree
-    from tree import Tree
-
-    # plant a new tree
-    my_tree = Tree()
-
-When you plant a new tree, the first thing it tries to do is set a `TREE_DIR` and `SAS_BASE_DIR` environment variable.
-`Tree` always first checks for already-defined environment variables in the users environment, and uses those if found.
-Otherwise it sets default locations for `TREE_DIR` and `SAS_BASE_DIR`.  The default location for `TREE_DIR` will be the location
-of the installed package.  The default location for `SAS_BASE_DIR` will be a new `sas` directory in the users home directory.
-By default, it will load all the paths set within the ``sdsswork`` configuration and populate your local Python environment,
-`os.environ`, if they are not currently found.
-
-To only load a subset of environment variables, use the `key` keyword argument.
-
+This product provides a Python package version of the `.Tree`.  See the :ref:`installation <install>` instructions.
+To use the tree, and set up its environment variables, you may simply import it
 ::
 
-    # only load MaNGA environment variables
-    my_tree = Tree(key='manga')
+    >>> # import the tree
+    >>> from tree import Tree
 
-    # load MaNGA and eBOSS
-    my_tree = Tree(key=['eboss', 'manga'])
+    >>> # plant a new tree
+    >>> my_tree = Tree()
 
-The environment variables for the specified keys are now loaded into your Python `os` environment::
+When you plant a new tree, the first thing it tries to do is set a `TREE_DIR` and `SAS_BASE_DIR` environment variable.
+``Tree`` always first checks for already-defined environment variables in the users environment, and uses those if found.
+Otherwise it sets default locations for `TREE_DIR` and `SAS_BASE_DIR`.  The default location for `TREE_DIR` will be the location
+of the installed package.  The default location for `SAS_BASE_DIR` will be a new ``sas`` directory in the users home directory.
+By default, it will load all the paths set within the ``sdsswork`` configuration and populate your local Python environment,
+``os.environ``, if they are not currently found.
 
-    import os
-    os.environ['MANGA_SPECTRO_REDUX']
+Loading only subsets
+--------------------
 
-You can load a new section into an existing tree with ``add_limbs``::
+To only load a subset of environment variables, use the ``key`` keyword argument.
+::
 
-    # adds the APO tree section into your os environment
-    my_tree.add_limbs(key='apo')
+    >>> # only load MaNGA environment variables
+    >>> my_tree = Tree(key='manga')
 
-You can load a tree with a different configuration. ::
+    >>> # load MaNGA and eBOSS
+    >>> my_tree = Tree(key=['eboss', 'manga'])
 
-    dr15_tree = Tree(config='dr15')
+The environment variables for the specified keys are now loaded into your Python ``os`` environment
+::
+
+    >>> import os
+    >>> os.environ['MANGA_SPECTRO_REDUX']
+
+You can load a new section into an existing tree with `.Tree.add_limbs`
+::
+
+    >>> # adds the APO tree section into your os environment
+    >>> my_tree.add_limbs(key='apo')
+
+
+Dynamically switching configurations
+------------------------------------
+
+You can load a tree with a different configuration.
+::
+
+    >>> dr15_tree = Tree(config='dr15')
 
 Instantiating a tree in this way will not overwrite any existing, or prior set, environment variables.  To
 update existing tree environment variables after loading one configuration within the same session, you
-can use ``replant_tree``::
-
-    # load the default tree
-    my_tree = Tree()
-
-    # switch to the dr15 tree
-    my_tree.replant_tree(config='dr15')
-
-To see what configs are available to load with `Tree`, use the ``list_available_configs`` method.
+can use `.Tree.replant_tree`
 ::
 
-    my_tree = Tree()
-    my_tree.list_available_configs()
-    ['bosswork.cfg', 'dr7.cfg', 'dr8.cfg', 'dr9.cfg', 'dr10.cfg', 'dr11.cfg', 'dr12.cfg', 
+    >>> # load the default tree
+    >>> my_tree = Tree()
+
+    >>> # switch to the dr15 tree
+    >>> my_tree.replant_tree(config='dr15')
+
+If you wish to preserve your original os environment during a tree replanting, set ``preserve_envvars=True``.
+::
+
+    >>> # switch to the sdss5 tree, preserving your entire original os environment
+    >>> my_tree.replant_tree('sdss5', preserve_envvars=True)
+
+Alternatively, you can preserve only a subset of environment variables by passing in a list.
+::
+
+    >>> # switch to the sdss5 tree, preserving a single envvar
+    >>> my_tree.replant_tree('sdss5', preserve_envvars=['ROBOSTRATEGY_DIR'])
+
+
+Accessing your original environment
+-----------------------------------
+
+To recover a copy of your original Python session ``os.environ``, use `.Tree.get_orig_os_environ`.
+::
+
+    >>> # get original os environ
+    >>> orig = my_tree.get_orig_os_environ()
+
+You can also reset the existing ``os.environ`` to its original state with `.Tree.reset_os_environ`.
+::
+
+    >>> # reset the os.environ
+    >>> my_tree.reset_os_environ()
+
+Seeing what's available
+-----------------------
+
+To see what configurations are available to load with `.Tree`, use the `.Tree.list_available_configs` method.
+::
+
+    >>> my_tree = Tree()
+    >>> my_tree.list_available_configs()
+    ['bosswork.cfg', 'dr7.cfg', 'dr8.cfg', 'dr9.cfg', 'dr10.cfg', 'dr11.cfg', 'dr12.cfg',
     'dr13.cfg', 'dr14.cfg', 'dr15.cfg', 'dr16.cfg', 'mpl9.cfg', 'sdss5.cfg', 'sdsswork.cfg']
 
-To see the available data releases, use the ``get_available_releases`` method.  This will return a list of
+Once a config is loaded into the ``Tree``, you can examin
+
+
+To see the available data releases, use the `.Tree.get_available_releases` method.  This will return a list of
 all public Data Release (DR) versions along with any additional survey versions, e.g. MaNGA's MPLs.  Any config
-files that end with ``work`` get combined into a single ``work`` release.  
+files that end with ``work`` get combined into a single ``work`` release.
 ::
 
-    my_tree = Tree()
-    my_tree.get_available_releases()
+    >>> my_tree = Tree()
+    >>> my_tree.get_available_releases()
     ['WORK', 'DR7', 'DR8', 'DR9', 'DR10', 'DR11', 'DR12', 'DR13', 'DR14', 'DR15', 'DR16']
 
-    # return only the public data releases
-    my_tree.get_available_releases(public=True)
+    >>> # return only the public data releases
+    >>> my_tree.get_available_releases(public=True)
     ['DR7', 'DR8', 'DR9', 'DR10', 'DR11', 'DR12', 'DR13', 'DR14', 'DR15', 'DR16']
 
 .. _tree-api:
 
 Reference/API
-^^^^^^^^^^^^^
+-------------
 
 .. rubric:: Class
 
-.. autosummary:: tree.Tree
+.. autosummary:: tree.tree.Tree
 
 .. rubric:: Methods
 
 .. autosummary::
 
-    tree.Tree.add_limbs
-    tree.Tree.list_keys
-    tree.Tree.replant_tree
+    tree.tree.Tree.add_limbs
+    tree.tree.Tree.list_keys
+    tree.tree.Tree.replant_tree
+    tree.tree.Tree.get_available_releases
+    tree.tree.Tree.get_orig_os_environ
+    tree.tree.Tree.list_available_configs
+    tree.tree.Tree.set_product_root
 

--- a/docs/sphinx/intro.rst
+++ b/docs/sphinx/intro.rst
@@ -15,15 +15,38 @@ To use the tree, and set up its environment variables, you may simply import it
     >>> # import the tree
     >>> from tree import Tree
 
-    >>> # plant a new tree
+    >>> # load the default sdsswork tree
     >>> my_tree = Tree()
+    >>> my_tree
+    Tree(sas_base_dir=/Users/Brian/Work/sdss/sas, config=sdsswork)
 
-When you plant a new tree, the first thing it tries to do is set a `TREE_DIR` and `SAS_BASE_DIR` environment variable.
+When you create a new tree, it will first try to load any default environment module already loaded, identified using the `TREE_VER`
+environment variable.  If it cannot find one, it will try to set a `TREE_DIR` and `SAS_BASE_DIR` environment variable.
 ``Tree`` always first checks for already-defined environment variables in the users environment, and uses those if found.
 Otherwise it sets default locations for `TREE_DIR` and `SAS_BASE_DIR`.  The default location for `TREE_DIR` will be the location
 of the installed package.  The default location for `SAS_BASE_DIR` will be a new ``sas`` directory in the users home directory.
 By default, it will load all the paths set within the ``sdsswork`` configuration and populate your local Python environment,
 ``os.environ``, if they are not currently found.
+
+To load a different tree environment, simply pass in a new configuration name.
+::
+
+    >>> # load the environment for DR15
+    >>> my_tree = Tree('dr15')
+    >>> my_tree
+    Tree(sas_base_dir=/Users/Brian/Work/sdss/sas, config=dr15)
+
+The underlying dictionary of environment variable definitions is accessible via the ``environ`` attribute.  The underlying dictionary
+of ``sdss_access`` path templates for the given environment is accessible via the ``paths`` attribute.
+::
+
+    >>> # access an environment variable definition
+    >>> my_tree.environ['MANGA']['MANGA_SPECTRO_REDUX']
+    '/Users/Brian/Work/sdss/sas/dr15/manga/spectro/redux'
+
+    >>> # access a path defintion
+    >>> my_tree.paths['mangacube']
+    '$MANGA_SPECTRO_REDUX/{drpver}/{plate}/stack/manga-{plate}-{ifu}-{wave}CUBE.fits.gz'
 
 Loading only subsets
 --------------------
@@ -49,14 +72,22 @@ You can load a new section into an existing tree with `.Tree.add_limbs`
     >>> # adds the APO tree section into your os environment
     >>> my_tree.add_limbs(key='apo')
 
+To see what keys are available in the currently loaded ``Tree``, use `.Tree.list_keys`.
+::
+
+    >>> my_tree.list_keys()
+    ['EBOSS', 'MANGA']
+
 
 Dynamically switching configurations
 ------------------------------------
 
-You can load a tree with a different configuration.
+You can load a tree environment with a different configuration during instantiation.
 ::
 
-    >>> dr15_tree = Tree(config='dr15')
+    >>> my_tree = Tree(config='dr15')
+    >>> my_tree
+    Tree(sas_base_dir=/Users/Brian/Work/sdss/sas, config=dr15)
 
 Instantiating a tree in this way will not overwrite any existing, or prior set, environment variables.  To
 update existing tree environment variables after loading one configuration within the same session, you
@@ -69,7 +100,8 @@ can use `.Tree.replant_tree`
     >>> # switch to the dr15 tree
     >>> my_tree.replant_tree(config='dr15')
 
-If you wish to preserve your original os environment during a tree replanting, set ``preserve_envvars=True``.
+If you wish to preserve your original os environment during a tree replanting, set ``preserve_envvars=True``.  This will preserve your
+entire ``os.environ``.
 ::
 
     >>> # switch to the sdss5 tree, preserving your entire original os environment
@@ -79,7 +111,20 @@ Alternatively, you can preserve only a subset of environment variables by passin
 ::
 
     >>> # switch to the sdss5 tree, preserving a single envvar
-    >>> my_tree.replant_tree('sdss5', preserve_envvars=['ROBOSTRATEGY_DIR'])
+    >>> my_tree.replant_tree('sdss5', preserve_envvars=['ROBOSTRATEGY_DATA'])
+
+If you wish to permanently preserve your locally set environment variables, you can set the ``preserve_envvars`` parameter to ``true`` in
+a custom tree YAML configuration file located at ``~/.config/sdss/tree.yml``.  For example
+::
+
+    preserve_envvars: true
+
+Alternatively, you can permanently set a subset of environment variables to preserve by defining a list.
+::
+
+    preserve_envvars:
+      - ROBOSTRATEGY_DATA
+      - ALLWISE_DIR
 
 
 Accessing your original environment
@@ -100,7 +145,7 @@ You can also reset the existing ``os.environ`` to its original state with `.Tree
 Seeing what's available
 -----------------------
 
-To see what configurations are available to load with `.Tree`, use the `.Tree.list_available_configs` method.
+To see what environment configurations are available to load with `.Tree`, use the `.Tree.list_available_configs` method.
 ::
 
     >>> my_tree = Tree()
@@ -108,11 +153,8 @@ To see what configurations are available to load with `.Tree`, use the `.Tree.li
     ['bosswork.cfg', 'dr7.cfg', 'dr8.cfg', 'dr9.cfg', 'dr10.cfg', 'dr11.cfg', 'dr12.cfg',
     'dr13.cfg', 'dr14.cfg', 'dr15.cfg', 'dr16.cfg', 'mpl9.cfg', 'sdss5.cfg', 'sdsswork.cfg']
 
-Once a config is loaded into the ``Tree``, you can examin
-
-
 To see the available data releases, use the `.Tree.get_available_releases` method.  This will return a list of
-all public Data Release (DR) versions along with any additional survey versions, e.g. MaNGA's MPLs.  Any config
+all public Data Release (DR) versions along with any internal survey release versions, e.g. MaNGA's MPLs.  Any config
 files that end with ``work`` get combined into a single ``work`` release.
 ::
 
@@ -123,6 +165,16 @@ files that end with ``work`` get combined into a single ``work`` release.
     >>> # return only the public data releases
     >>> my_tree.get_available_releases(public=True)
     ['DR7', 'DR8', 'DR9', 'DR10', 'DR11', 'DR12', 'DR13', 'DR14', 'DR15', 'DR16']
+
+To show the environments for all possible configurations, use `.Tree.show_forest`.  It returns a dictionary of all configurations
+and their defined environment variables.
+::
+
+    >>> # get all possible environments
+    >>> envs = my_tree.show_forest()
+    >>> envs.keys()
+    dict_keys(['bosswork', 'dr10', 'dr11', 'dr12', 'dr13', 'dr14', 'dr15', 'dr16', 'dr17', 'dr7',
+    'dr8', 'dr9', 'mpl10', 'mpl3', 'mpl4', 'mpl5', 'mpl6', 'mpl7', 'mpl8', 'mpl9', 'sdss5', 'sdsswork'])
 
 .. _tree-api:
 
@@ -140,8 +192,10 @@ Reference/API
     tree.tree.Tree.add_limbs
     tree.tree.Tree.list_keys
     tree.tree.Tree.replant_tree
-    tree.tree.Tree.get_available_releases
     tree.tree.Tree.get_orig_os_environ
+    tree.tree.Tree.reset_os_environ
     tree.tree.Tree.list_available_configs
+    tree.tree.Tree.get_available_releases
+    tree.tree.Tree.show_forest
     tree.tree.Tree.set_product_root
 

--- a/docs/sphinx/paths.rst
+++ b/docs/sphinx/paths.rst
@@ -184,7 +184,7 @@ sets itself to the first defined path it finds.  It looks for the following defi
 - SDSS_PRODUCT_ROOT
 - SDSS4_PRODUCT_ROOT
 
-You can also manually set the product root in Python with ``tree.set_product_root()`` method.  Or you can optionally set the `PRODUCT_ROOT`
+You can also manually set the product root in Python with `.Tree.set_product_root()` method.  Or you can optionally set the `PRODUCT_ROOT`
 manually by setting the `PRODUCT_ROOT` parameter in your custom config file, ``~/.config/tree/tree.yml``
 
 As an example, let's take the addition of the MaNGA preimaging files, which are a part of the ``mangapreim`` svn software repository.
@@ -203,6 +203,7 @@ If the product was also released as a tag for a public data release, and hosted 
 the environment variable to the proper location in the appropriate ``drXX.cfg`` file.  In our MaNGA pre-imaging example, we set the following
 within the `dr15.cfg <https://github.com/sdss/tree/blob/master/data/dr15.cfg>`_ file.
 ::
+
     [MANGA]
     MANGAPREIM_DIR = $PRODUCT_ROOT/data/manga/mangapreim/tags/v2_5
 

--- a/docs/sphinx/tree_envs.rst
+++ b/docs/sphinx/tree_envs.rst
@@ -1,5 +1,8 @@
 
-:tocdepth: 1
+:tocdepth: 2
+
+Tree Environments
+=================
 
 .. _sdsswork:
 

--- a/docs/sphinx/tree_setup.rst
+++ b/docs/sphinx/tree_setup.rst
@@ -181,6 +181,19 @@ To control where `setup_tree` creates the environment files, specify the ``--pat
     # specify a custom output path
     setup_tree.py -v -p /my_output/environment/configs/
 
+Generating the old sdss_paths.ini file
+--------------------------------------
+
+Starting with ``tree 3.0``, the old ``sdss_paths.ini`` file, was deprecated and removed in favor of defining ``sdss_access`` paths within
+each tree environment configuration file to allow for versioning of path definitions.  Some applications may still require the old
+``sdss_paths.ini`` file.  To generate the legacy file, use `.Tree.write_old_paths_inifile`.  This will produce the old in the proper location
+to be usable by legacy codes.  It will generate the file for the currently loaded environment
+::
+
+    >>> # generate an old paths ini file for sdsswork
+    >>> tree = Tree('sdsswork')
+    >>> tree.write_old_paths_inifile()
+
 
 Creating Environment Symlinks
 =============================

--- a/python/tree/etc/tree.yml
+++ b/python/tree/etc/tree.yml
@@ -2,6 +2,7 @@
 ---
 
 PRODUCT_ROOT: null
+preserve_envvars: null
 
 
 

--- a/python/tree/tree.py
+++ b/python/tree/tree.py
@@ -33,30 +33,40 @@ class Tree(object):
 
     This class provides Python programmatic access to the SDSS tree envionment structure
 
-    Parameters:
-        key (str|list):
+    Parameters
+    ----------
+        key : str | list
             A section or list of sections of the tree to add into the local environment
-        uproot_with (str):
+        uproot_with : str
             A new TREE_DIR path used to override an existing TREE_DIR environment variable
-        config (str):
+        config : str
             Name of manual config file to load.  Default is sdsswork.
-        update (bool):
+        update : bool
             If True, overwrites existing tree environment variables in your
             local environment.  Default is False.
-        exclude (list):
+        exclude : list
             A list of environment variables to exclude
             from forced updates
-        root (str):
+        root : str
             An absolute directory path to override as the software product root
-        git (bool):
+        git : bool
             If True, looks for SDSS_GIT_ROOT environment variable as product root instead
             of SDSS_SVN_ROOT
 
-    Attributes:
-        treedir (str):
+    Attributes
+    ----------
+        treedir : str
             The directory of the tree
-        environ (dict):
-            The fully loaded SDSS config file held internally
+        sasbasedir : str
+            The root directory of SAS
+        productroot_dir : str
+            The root directory of installed software products from svn or github
+        environ : dict
+            All of the environment paths defnined in the currntly loaded SDSS configuration file
+        paths : dict
+            All of the sdss_access paths defined in the currently loaded configuration
+        phase : int
+            Which SDSS phase the currently loaded config belongs to
 
     '''
     # possible software product roots
@@ -107,8 +117,9 @@ class Tree(object):
     def set_roots(self, uproot_with=None):
         ''' Set the roots of the tree in the os environment
 
-        Parameters:
-            uproot_with (str):
+        Parameters
+        ----------
+            uproot_with : str
                 A new TREE_DIR path used to override an existing TREE_DIR environment variable
 
         '''
@@ -133,13 +144,16 @@ class Tree(object):
         is identified, then recursively reads in all cfg files and builds
         a master config dictionary object
 
-        Parameters:
-            config (str):
+        Parameters
+        ----------
+            config : str
                 Optional name of config file to load
-            bases (list):
+            bases : list
                 A list of parent config files
 
-        Returns:
+        Returns
+        -------
+        dict
             A configParser dictionary object
         '''
 
@@ -178,11 +192,14 @@ class Tree(object):
         checks the config for syntax and existence.  Defaults to sdsswork
         or a DR if it doesn't exist.
 
-        Parameters:
-            config (str):
+        Parameters
+        ----------
+            config : str
                 The name of the config to check
 
-        Returns:
+        Returns
+        -------
+        str
             The (updated) name of the config
         '''
 
@@ -210,8 +227,9 @@ class Tree(object):
     def load_config(self, config=None):
         ''' Load a config file
 
-        Parameters:
-            config (str):
+        Parameters
+        ----------
+            config : str
                 Optional name of manual config file to load
         '''
 
@@ -237,13 +255,16 @@ class Tree(object):
         Creates a dictionary with environment definitions
         expanded out
 
-        Parameters:
-            config (str):
+        Parameters
+        ----------
+            config : str
                 Optional name of manual config file to load
-            sections (list):
+            sections : list
                 A list of config sections to load
 
-        Returns:
+        Returns
+        -------
+        dict
             An ordered dictionary of envvar definitions
         '''
 
@@ -287,10 +308,13 @@ class Tree(object):
         Extracts the PATHS section from a ConfigParser object
         and builds a dictionary of paths for sdss_access
 
-        Parameters:
-            cfg (object):
+        Parameters
+        ----------
+            cfg : object
                 A configParser object
-        Returns:
+        Returns
+        -------
+        dict
             An ordered dictionary of sdss_access path definitions
         '''
 
@@ -318,8 +342,9 @@ class Tree(object):
         tree environment for access later. Optionally can specify a specific
         branch.  This does not yet load them into the os environment.
 
-        Parameters:
-            limb (str|list):
+        Parameters
+        ----------
+            limb : str | list
                 A section or lists of sections of the config to add into the environ
 
         '''
@@ -342,8 +367,9 @@ class Tree(object):
     def add_limbs(self, key=None):
         ''' Add a new section from the tree into the existing os environment
 
-        Parameters:
-            key (str):
+        Parameters
+        ----------
+            key : str
                 The section name to grab from the environment
 
         '''
@@ -353,14 +379,16 @@ class Tree(object):
     def get_paths(self, key):
         ''' Retrieve a set of environment paths from the config
 
-        Parameters:
-            key (str):
+        Parameters
+        ----------
+            key : str
                 The section name to grab from the environment
 
-        Returns:
-            self.environ[newkey] (OrderedDict):
-                An ordered dict containing all of the paths from the
-                specified section, as key:val = name:path
+        Returns
+        -------
+        dict
+            An ordered dict containing all of the paths from the
+            specified section, as key:val = name:path
         '''
         newkey = key if key in self.environ else key.upper() if key.upper() \
             in self.environ else None
@@ -375,10 +403,11 @@ class Tree(object):
         This code goes through the tree environ and checks
         for existence in the os environ, then adds them
 
-        Parameters:
-            key (str):
+        Parameters
+        ----------
+            key : str
                 The section name to check against / add
-            update (bool):
+            update : bool
                 If True, overwrites existing tree environment variables in your
                 local environment.  Default is False.
         '''
@@ -395,11 +424,12 @@ class Tree(object):
     def _check_paths(self, paths, update=None):
         ''' Check if the path is in the os environ, and if not add it
 
-        Paramters:
-            paths (OrderedDict):
+        Paramters
+        ---------
+            paths : dict
                 An ordered dict containing all of the paths from the
                 a given section, as key:val = name:path
-            update (bool):
+            update : bool
                 If True, overwrites existing tree environment variables in your
                 local environment.  Default is False.
         '''
@@ -419,7 +449,10 @@ class Tree(object):
         """ Replant the tree with a different config setup
 
         Resets the python tree with the new config.  Automatically updates the session
-        os.environ with the new tree config environment variables.
+        os.environ with the new tree config environment variables.  If ``preserve_envvars``
+        is set to True, preserves the original os environ during tree update.  If
+        ``preserve_envvars`` is set to a list of environment variables, preserves only that
+        subset.
 
         Parameters
         ----------
@@ -467,11 +500,14 @@ class Tree(object):
         Creates a dictionary environment for each config in the list of
         available configurations.
 
-        Parameters:
-            config (str):
+        Parameters
+        ----------
+            config : str
                 The config to show
 
-        Returns:
+        Returns
+        -------
+        dict
             A dictionary of config environment(s)
         '''
 
@@ -510,8 +546,9 @@ class Tree(object):
     def get_available_releases(cls, public=None):
         ''' Get the available releases
 
-        Parameters:
-            public (bool):
+        Parameters
+        ----------
+            public : bool
                 If True, only return public data releases
         '''
 
@@ -549,8 +586,9 @@ class Tree(object):
         Converts the nested ``tree.environ`` into a series of
         ordinary dicts.
 
-        Parameters:
-            collapse (bool):
+        Parameters
+        ----------
+            collapse : bool
                 If True, collapses nested dicts into a single dict.  Default is True.
         '''
         if collapse is False:
@@ -575,13 +613,16 @@ class Tree(object):
         PRODUCT_ROOT, SDSS_SVN_ROOT, SDSS_INSTALL_PRODUCT_ROOT, SDSS_PRODUCT_ROOT,
         SDSS4_PRODUCT_ROOT. If no root is found uses one directory up from SAS_BASE_DIR.
 
-        Parameters:
-            root (str):
+        Parameters
+        ----------
+            root : str
                 An absolute directory path to override as the product root
-            git (bool):
+            git : bool
                 If True, looks for SDSS_GIT_ROOT environment variable as product root.
 
-        Returns:
+        Returns
+        -------
+        dict
             The directory path to sdss-installed svn/git products
         '''
 
@@ -617,10 +658,11 @@ class Tree(object):
         SDSS_SVN_ROOT, SDSS_INSTALL_PRODUCT_ROOT, SDSS_PRODUCT_ROOT, SDSS4_PRODUCT_ROOT.
         If no root is found uses one directory up from SAS_BASE_DIR.
 
-        Parameters:
-            root (str):
+        Parameters
+        ----------
+            root : str
                 An absolute directory path to override as the product root
-            git (bool):
+            git : bool
                 If True, looks for SDSS_GIT_ROOT environment variable as product root.
 
         '''
@@ -665,11 +707,14 @@ class Tree(object):
 def get_tree_dir(uproot_with=None):
     ''' Return the path to the tree product directory
 
-    Parameters:
-        uproot_with (str):
+    Parameters
+    ----------
+        uproot_with : str
             A new TREE_DIR path used to override an existing TREE_DIR environment variable
 
-    Returns:
+    Returns
+    -------
+    str
         The path to the tree python product directory
     '''
     treedir = os.environ.get('TREE_DIR', None) if not uproot_with else uproot_with

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ package_dir =
 install_requires =
     pygments>=2.6
     configparser>=3.5.0
-	sdsstools>=0.1.7
+	sdsstools>=0.4.5
 
 scripts =
 	bin/setup_tree.py
@@ -64,7 +64,7 @@ dev =
 	coverage[toml]>=5.0
     coveralls>=1.7
 	ipdb>=0.12.3
-	sdsstools[dev]>=0.1.0
+	sdsstools[dev]>=0.4.0
 	# The following are needed because sdsstools[dev] as an extra not always
 	# gets installed. See https://github.com/pypa/pip/issues/4957.
 	invoke>=1.3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -77,6 +77,7 @@ docs =
 	recommonmark>=0.6
 	sphinx-argparse>=0.2.5
 	sphinx-issues>=1.2.0
+	importlib_metadata>=1.6.0
 
 [isort]
 line_length = 100

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,6 +76,7 @@ docs =
 	sphinx_bootstrap_theme>=0.4.12
 	recommonmark>=0.6
 	sphinx-argparse>=0.2.5
+	sphinx-issues>=1.2.0
 
 [isort]
 line_length = 100

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,8 @@ from __future__ import absolute_import
 import os
 import shutil
 import pytest
-
+import importlib
+import tree.tree as treemod
 
 def make_dirs(path):
     (path / 'dr14/manga/spectro/redux/v2_1_2').mkdir(parents=True)
@@ -41,3 +42,11 @@ def faketree(monkeypatch, tmp_path):
     mdir = p / 'modules'
     mdir.mkdir(parents=True)
     monkeypatch.setenv('MODULES_DIR', str(mdir))
+
+
+@pytest.fixture()
+def monkeysdss5(monkeypatch):
+    monkeypatch.setenv('ALLWISE_DIR', '/tmp/allwise')
+    monkeypatch.setenv('EROSITA_DIR', '/tmp/erosita')
+    monkeypatch.setenv('ROBOSTRATEGY_DATA', '/tmp/robodata')
+    importlib.reload(treemod)


### PR DESCRIPTION
This PR adds support to preserve a user's original python session `os.environ` when updating a tree environment dynamically with `tree.replant_tree()`.  `replant_tree` now accepts a `preserve_envvars` keyword which can be set to `True` to preserve the users original `os.environ` in its entirety.  It can also accept a list of environment variables to preserve only a subset of envvars.  Alternatively the `preserve_envvars` parameter can also be set within the custom YAML config file, `~/.config/sdss/tree.yml` to permanently set preservation.