### PR TITLE
Add boss spSpec path to sdss5

### DIFF
--- a/data/sdss5.cfg
+++ b/data/sdss5.cfg
@@ -221,3 +221,6 @@ asR = $APOGEE_DATA_2S/{mjd}/asR-{chip}-{num:0>8}.apz
 aspcapField = $APOGEE_ASPCAP/{apred}/{aspcap}/{telescope}/{field}/aspcapField-{field}.fits
 aspcapStar = $APOGEE_ASPCAP/{apred}/{aspcap}/{telescope}/{field}/aspcapStar-{apred}-{obj}.fits
 aspcapStar-1m = $APOGEE_ASPCAP/{apred}/{aspcap}/{telescope}/{field}/aspcapStar-{apred}-{reduction}.fits
+
+# boss paths
+spSpec = $BOSS_SPECTRO_REDUX/{run2d}/{plate}p/coadd/{mjd}/spSpec-{plate}-{mjd}-{max(fiberid, catalogid):0>11}.fits


### PR DESCRIPTION
As far as I can see, there aren't any path definitions for BOSS co-added spectra in the SDSS-V tree definitions. I think this is the correct definition, but I would like @hjibarram to confirm.

(I am opening this pull request because I would like Astra to run nicely on BOSS spectra without me having to write edge cases in for dealing with BOSS spectra).