### PR TITLE
add methods to identify envvar and ini section

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ Change Log
 
 This document records the main changes to the tree code.
 
+3.1.3 (unreleased)
+------------------
+- Add methods ``identify_envvar`` and ``identify_section`` to ``Tree`` class.
+
 3.1.2 (2022-05-13)
 ------------------
 - Includes updates and changes to sdss5 paths and envvars

--- a/python/tree/tree.py
+++ b/python/tree/tree.py
@@ -111,7 +111,7 @@ class Tree(object):
         if phase and phase.isdigit():
             phase = int(phase)
         return phase
-    
+
     @property
     def release_date(self):
         ''' Return the release date of the tree configuration '''
@@ -529,12 +529,12 @@ class Tree(object):
         if len(configs) == 1:
             return cfgs[cfg_name]
         return cfgs
-    
+
     @staticmethod
     def _sort_configs(release: str = 'dr', cfgs: list = None) -> list:
         """ Sort the list of configs by a release group
 
-        Sorts the list of configs by a release group, e.g. 
+        Sorts the list of configs by a release group, e.g.
         'DR', 'MPL', or "IPL". Within each group sorts by the integer
         number of the release.
 
@@ -765,12 +765,12 @@ class Tree(object):
     def check_missing_path_envvars(self):
         """ Checks paths envars against main envvar list
 
-        Extracts the used environment variables from all the 
-        sdss_access path definitions in tree.paths, and checks them 
-        against the list of defined environment variables in tree.environ.  
-        Returns a list of any path environment variables that are 
-        missing from the valid definitions in the environment.  
-        
+        Extracts the used environment variables from all the
+        sdss_access path definitions in tree.paths, and checks them
+        against the list of defined environment variables in tree.environ.
+        Returns a list of any path environment variables that are
+        missing from the valid definitions in the environment.
+
         Returns
         -------
         list
@@ -778,11 +778,25 @@ class Tree(object):
         """
         # get the list of environment variables
         envvars = self.to_dict().keys()
-        
+
         # get the list of access paths and extract envvars
         paths = self.paths.values()
         path_envvars = set(re.findall(r'\$(.*?)\/', '\t'.join(paths)))
         return [i for i in path_envvars if i not in envvars]
+
+    def identify_envvar(self, file):
+        """ Identifies the environment variable used in a file path """
+        env = None
+        for env, val in reversed(list(self.to_dict().items())):
+             if val in file:
+                 return env
+
+    def identify_section(self, envvar):
+        """ Identifies the tree ini section from an environment variable """
+        sec = None
+        for sec, envs in self.environ.items():
+             if envvar in envs:
+                 return sec
 
 def get_tree_dir(uproot_with=None):
     ''' Return the path to the tree product directory
@@ -851,7 +865,7 @@ def _get_history(name: str, cfg_type: str) -> dict:
 def get_envvar_history(name: str) -> dict:
     """ Get the history of a given environment variable
 
-    Returns a dictionary of the given environment variable definition in all 
+    Returns a dictionary of the given environment variable definition in all
     available tree config files.
 
     Parameters
@@ -870,7 +884,7 @@ def get_envvar_history(name: str) -> dict:
 def get_path_history(name: str) -> dict:
     """ Get the history of a given access path name
 
-    Returns a dictionary of the given acess path definition in all 
+    Returns a dictionary of the given acess path definition in all
     available tree config files.
 
     Parameters

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,7 @@ def faketree(monkeypatch, tmp_path):
     mdir = p / 'modules'
     mdir.mkdir(parents=True)
     monkeypatch.setenv('MODULES_DIR', str(mdir))
+    yield str(p)
 
 
 @pytest.fixture()

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -242,12 +242,35 @@ class TestTree(object):
         tree = Tree(config='sdsswork')
         tree.replant_tree('sdss5')
         self.assert_subset_envvars()
-        
+
     def test_missing_path_envvars(self, tree):
         # remove an envvar
         tree.environ['MANGA'].pop("MANGA_SWIM")
         missing = tree.check_missing_path_envvars()
         assert "MANGA_SWIM" in missing
+
+    @pytest.mark.parametrize('file, envvar',
+                             [('mangawork/manga/spectro/redux/v3_1_1/8485/file.txt', 'MANGA_SPECTRO_REDUX'),
+                              ('ebosswork/eboss/file.txt', 'EBOSS_ROOT'),
+                              ('file.txt', 'SAS_BASE_DIR'),
+                              ('/root/dir/file.txt', None)],
+                             ids=['manga', 'eboss', 'sas', 'none'])
+    def test_identify_envvar(self, faketree, tree, file, envvar):
+        """ test we can identify an envvar from a file """
+        path = os.path.join(faketree, file)
+        ee = tree.identify_envvar(path)
+        assert envvar == ee
+
+    @pytest.mark.parametrize('envvar, sec',
+                             [('MANGA_SPECTRO_REDUX', 'MANGA'),
+                              ('EBOSS_ROOT', 'EBOSS'),
+                              ('SAS_BASE_DIR', 'general'),
+                              ('NO_ENVVAR', None)],
+                             ids=['manga', 'eboss', 'sas', 'none'])
+    def test_identify_section(self, tree, envvar, sec):
+        """ test we can identify an ini section from an envvar """
+        ss = tree.identify_section(envvar)
+        assert sec == ss
 
 
 def test_get_path_history():


### PR DESCRIPTION
Adds two methods to the python tree, `identify_envvar` and `identify_section`.  `identify_envvar` attempts to identify the relevant environment variable given an absolute filepath.  `identify_section` attempts to identify the relevant ini config section given an environment variable. 