### PR TITLE
Add path definitions for mwmVisit and mwmStar products

### DIFF
--- a/data/sdss5.cfg
+++ b/data/sdss5.cfg
@@ -263,3 +263,7 @@ spAllLineField = $BOSS_SPECTRO_REDUX/{run2d}/spectra/full/@pad_fieldid|@isplate|
 #
 confSummary = $SDSSCORE_DIR/{obs}/summary_files/@configgrp|/confSummary-{configid}.par
 confSummaryF = $SDSSCORE_DIR/{obs}/summary_files/@configgrp|/confSummaryF-{configid}.par
+
+# Astra paths
+mwmVisit = $MWM_ASTRA/{astra_version}/{run2d}-{apred}/spectra/visit/@healpixgrp|/{healpix}/mwmVisit-{astra_version}-{catalogid}@component_default|.fits
+mwmStar = $MWM_ASTRA/{astra_version}/{run2d}-{apred}/spectra/star/@healpixgrp|/{healpix}/mwmStar-{astra_version}-{catalogid}@component_default|.fits

--- a/data/sdss5.cfg
+++ b/data/sdss5.cfg
@@ -265,5 +265,5 @@ confSummary = $SDSSCORE_DIR/{obs}/summary_files/@configgrp|/confSummary-{configi
 confSummaryF = $SDSSCORE_DIR/{obs}/summary_files/@configgrp|/confSummaryF-{configid}.par
 
 # Astra paths
-mwmVisit = $MWM_ASTRA/{astra_version}/{run2d}-{apred}/spectra/visit/@healpixgrp|/{healpix}/mwmVisit-{astra_version}-{catalogid}@component_default|.fits
-mwmStar = $MWM_ASTRA/{astra_version}/{run2d}-{apred}/spectra/star/@healpixgrp|/{healpix}/mwmStar-{astra_version}-{catalogid}@component_default|.fits
+mwmVisit = $MWM_ASTRA/{astra_version}/{run2d}-{apred}/spectra/visit/@catalogid_groups|/mwmVisit-{astra_version}-{catalogid}@component_default|.fits
+mwmStar = $MWM_ASTRA/{astra_version}/{run2d}-{apred}/spectra/star/@catalogid_groups|/mwmStar-{astra_version}-{catalogid}@component_default|.fits


### PR DESCRIPTION
This PR adds path definitions for mwmVisit and mwmStar data products.

Each product is uniquely defined by `catalogid` (SDSS-V catalog identifier), the `healpix` the source falls in to, and relevant software versions: `apred`, `run2d`, `astra_version`. 

In MWM we know that for some stellar systems we can reliably separate out spectra from two sources (i.e., spectroscopic binary; a primary and a secondary). To future-proof this path I have included a `component_default` special function, which has a companion pull request open at https://github.com/sdss/sdss_access/pull/31

If a `component` keyword is given when resolving the path to a mwmVisit/mwmStar product, then that component value will be used. If no `component` is given, then the `component_default` special function will resolve the component to an empty string ('').