### PR TITLE
Fixes a broken doc test

### DIFF
--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -74,7 +74,7 @@ release = __version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,7 +72,7 @@ dev =
 	wheel>=0.33.6
 
 docs =
-	Sphinx>=3.0.0
+	Sphinx>=7.2.0
 	sphinx_bootstrap_theme>=0.4.12
 	recommonmark>=0.6
 	sphinx-argparse>=0.2.5

--- a/tests/test_docutree.py
+++ b/tests/test_docutree.py
@@ -18,11 +18,11 @@ def test_docutree(app, status, warning):
     dmdoc = app.srcdir / "_build/html/contents.html"
     assert dmdoc.exists()
 
-    tt =  dmdoc.read_text()
+    tt = dmdoc.read_text()
 
     # check for datamodel directive stuff
     assert '<section id="datamodel">' in tt
-    assert '<h2>SDSS<a class="headerlink" href="#sdss" title="Permalink to this heading">¶</a></h2>' in tt
+    assert '<h2>SDSS<a class="headerlink" href="#sdss" title="Link to this heading">¶</a></h2>' in tt
     assert "<td><p>MANGA_SPECTRO_REDUX</p></td>\n<td><p>/dr17/manga/spectro/redux</p></td>" in tt
 
     # check for changelog directive stuff


### PR DESCRIPTION
This fixes a test that was broken by the Sphinx package bump to >7.2.  The updates the test and pins the minimum Sphinx version as >7.2