### PR TITLE
Add paths for AG, guider data, and coadds

### DIFF
--- a/data/sdsswork.cfg
+++ b/data/sdsswork.cfg
@@ -486,10 +486,10 @@ lvm_agcam = $AGCAM_DATA_S/{mjd}/lvm.{tel}.agcam.{camera}_{expnum:0>8}.fits
 lvm_agcam_sources = $AGCAM_DATA_S/{mjd}/lvm.{tel}.agcam.{camera}_{expnum:0>8}.parquet
 lvm_guider = $AGCAM_DATA_S/{mjd}/lvm.{tel}.guider_{expnum:0>8}.fits
 lvm_guider_sources = $AGCAM_DATA_S/{mjd}/lvm.{tel}.guider_{expnum:0>8}.parquet
-lvm_coadd = $AGCAM_DATA_S/{mjd}/coadds/lvm.{tel}.coadd_s{specframe:0>8}.fits
-lvm_coadd_frames = $AGCAM_DATA_S/{mjd}/coadds/lvm.{tel}.coadd_s{specframe:0>8}_frames.parquet
-lvm_coadd_guiderdata = $AGCAM_DATA_S/{mjd}/coadds/lvm.{tel}.coadd_s{specframe:0>8}_guiderdata.parquet
-lvm_coadd_sources = $AGCAM_DATA_S/{mjd}/coadds/lvm.{tel}.coadd_s{specframe:0>8}_sources.parquet
+lvm_agcam_coadd = $AGCAM_DATA_S/{mjd}/coadds/lvm.{tel}.coadd_s{specframe:0>8}.fits
+lvm_agcam_coadd_frames = $AGCAM_DATA_S/{mjd}/coadds/lvm.{tel}.coadd_s{specframe:0>8}_frames.parquet
+lvm_agcam_coadd_guiderdata = $AGCAM_DATA_S/{mjd}/coadds/lvm.{tel}.coadd_s{specframe:0>8}_guiderdata.parquet
+lvm_agcam_coadd_sources = $AGCAM_DATA_S/{mjd}/coadds/lvm.{tel}.coadd_s{specframe:0>8}_sources.parquet
 
 
 # HIPS paths

--- a/data/sdsswork.cfg
+++ b/data/sdsswork.cfg
@@ -482,6 +482,15 @@ lvm_dap = $LVM_SPECTRO_ANALYSIS/{drpver}/{dapver}/{tileid}/lvm-{tileid}-{daptype
 lvm_drpall = $LVM_SPECTRO_REDUX/{drpver}/drpall-{drpver}.fits
 lvm_dapall = $LVM_SPECTRO_ANALYSIS/{drpver}/{dapver}/dapall-{drpver}-{dapver}.fits
 lvm_calib = $LVM_MASTER_DIR/{mjd}/lvm-m{kind}-{camera}.fits
+lvm_agcam = $AGCAM_DATA_S/{mjd}/lvm.{tel}.agcam.{camera}_{expnum:0>8}.fits
+lvm_agcam_sources = $AGCAM_DATA_S/{mjd}/lvm.{tel}.agcam.{camera}_{expnum:0>8}.parquet
+lvm_guider = $AGCAM_DATA_S/{mjd}/lvm.{tel}.guider_{expnum:0>8}.fits
+lvm_guider_sources = $AGCAM_DATA_S/{mjd}/lvm.{tel}.guider_{expnum:0>8}.parquet
+lvm_coadd = $AGCAM_DATA_S/{mjd}/coadds/lvm.{tel}.coadd_s{specframe:0>8}.fits
+lvm_coadd_frames = $AGCAM_DATA_S/{mjd}/coadds/lvm.{tel}.coadd_s{specframe:0>8}_frames.parquet
+lvm_coadd_guiderdata = $AGCAM_DATA_S/{mjd}/coadds/lvm.{tel}.coadd_s{specframe:0>8}_guiderdata.parquet
+lvm_coadd_sources = $AGCAM_DATA_S/{mjd}/coadds/lvm.{tel}.coadd_s{specframe:0>8}_sources.parquet
+
 
 # HIPS paths
 sdss_moc = $SDSS_HIPS/{release}/{survey}/Moc.{ext}


### PR DESCRIPTION
This PR adds paths for LVM guider files and co-added frames.

Examples
```python
>> from sdss_access import Path

>> p = Path()
>> p.url('lvm_agcam', mjd=60268, tel='skyw', camera='east', expnum=693)
'https://data.sdss5.org/sas/sdsswork/data/agcam/lco/60268/lvm.skyw.agcam.east_00000693.fits'

>> p.url('lvm_guider', mjd=60268, tel='skyw', expnum=693)
'https://data.sdss5.org/sas/sdsswork/data/agcam/lco/60268/lvm.skyw.guider_00000693.fits'

>> p.url('lvm_coadd', mjd=60268, tel='sci', specframe=7963)
'https://data.sdss5.org/sas/sdsswork/data/agcam/lco/60268/coadds/lvm.sci.coadd_s00007963.fits'
```