### PR TITLE
Ipl3 sandbox

### DIFF
--- a/data/ipl3.cfg
+++ b/data/ipl3.cfg
@@ -21,7 +21,9 @@ MWM_ASTRA= %(IPL_ROOT)s/spectro/astra
 MWM_SSPP= %(IPL_ROOT)s/vac/mwm/sspp
 APOGEE_REDUX = %(IPL_ROOT)s/spectro/apogee/redux
 
-
+[VAC]
+VAC_ROOT = %(FILESYSTEM)s/%(name)s/vac
+APOGEE_DISTMASS = %(VAC_ROOT)s/mwm/apogee-distmass
 
 [PATHS]
 
@@ -218,3 +220,8 @@ astraAllStarSLAM = $MWM_ASTRA/{v_astra}/summary/astraAllStarSLAM-{v_astra}.fits
 astraAllVisitSLAM = $MWM_ASTRA/{v_astra}/summary/astraAllVisitSLAM-{v_astra}.fits
 astraAllStarSnowWhite = $MWM_ASTRA/{v_astra}/summary/astraAllStarSnowWhite-{v_astra}.fits
 astraAllVisitSnowWhite = $MWM_ASTRA/{v_astra}/summary/astraAllVisitSnowWhite-{v_astra}.fits
+
+# VAC paths
+# SDSS-V VAC 0003 
+apogee_distmass = $APOGEE_DISTMASS/APOGEE_IPL3_DistMass_{vers}.fits
+

--- a/data/sdsswork.cfg
+++ b/data/sdsswork.cfg
@@ -118,6 +118,7 @@ MWM_SANDBOX = %(MWM_ROOT)s/sandbox
 MWM_ASTRA = %(MWM_ROOT)s/spectro/astra
 MWM_HEALPIX = %(MWM_ROOT)s/spectro/healpix
 MWM_SSPP = %(MWM_ROOT)s/spectro/sspp
+APOGEE_DISTMASS = %(MWM_SANDBOX)s/DistMass
 APOGEE_REDUX = %(MWM_ROOT)s/apogee/spectro/redux
 APOGEE_ASPCAP = %(MWM_ROOT)s/apogee/spectro/aspcap
 APOGEE_TARGET = %(MWM_ROOT)s/apogee/target
@@ -491,6 +492,11 @@ lvm_agcam_coadd_frames = $AGCAM_DATA_S/{mjd}/coadds/lvm.{tel}.coadd_s{specframe:
 lvm_agcam_coadd_guiderdata = $AGCAM_DATA_S/{mjd}/coadds/lvm.{tel}.coadd_s{specframe:0>8}_guiderdata.parquet
 lvm_agcam_coadd_sources = $AGCAM_DATA_S/{mjd}/coadds/lvm.{tel}.coadd_s{specframe:0>8}_sources.parquet
 
+# VAC paths
+# SDSS-V VAC 0003 
+apogee_distmass = $APOGEE_DISTMASS/{vers}/APOGEE_IPL3_DistMass_{vers}.fits
 
 # HIPS paths
 sdss_moc = $SDSS_HIPS/{release}/{survey}/Moc.{ext}
+
+


### PR DESCRIPTION
add the apogee distmass vac, including the fits file staged on the SAS and announced via [SDSS-V VAC 0003](https://soji.sdss.utah.edu/collaboration/announcements/vacs/browse/select/sdss-5.3), including new paths configured in:
 * sdsswork: vac work folder in the mwm sandbox
 * ipl-3: frozen ipl folder in the mwm vac directory.
 
 