### PR TITLE
IPL-4

### DIFF
--- a/data/ipl4.cfg
+++ b/data/ipl4.cfg
@@ -1,0 +1,25 @@
+#
+# Tree configuration for SDSS-V IPL-4 release
+#
+#
+[DEFAULT]
+FILESYSTEM = @FILESYSTEM@
+name = ipl4
+base = ipl3
+current = True
+phase = 5
+release_date = 2024-02-29
+
+[BHM]
+name = ipl-4
+IPL_ROOT = %(FILESYSTEM)s/%(name)s
+# add any changes from IPL-3 here (none expected)
+
+
+[MWM]
+name = ipl-4
+IPL_ROOT = %(FILESYSTEM)s/%(name)s
+# add any changes from IPL-3 here (none expected)
+
+[PATHS]
+# no changes from IPL-3 

--- a/docs/sphinx/config.rst
+++ b/docs/sphinx/config.rst
@@ -25,6 +25,7 @@ configurations are the following:
 * :ref:`ipl1 <ipl1>` - the IPL-1 configuration for SDSS-V
 * :ref:`ipl2 <ipl2>` - the IPL-2 configuration for SDSS-V
 * :ref:`ipl3 <ipl3>` - the IPL-3 configuration for SDSS-V
+* :ref:`ipl4 <ipl4>` - the IPL-4 configuration for SDSS-V
 
 .. _tree_evolve:
 

--- a/docs/sphinx/tree_envs.rst
+++ b/docs/sphinx/tree_envs.rst
@@ -184,6 +184,8 @@ This is the configuration for IPL-3
    :title: ipl-3
    :remove-sasbase:
 
+.. _ipl4:
+
 IPL-4
 -----
 

--- a/docs/sphinx/tree_envs.rst
+++ b/docs/sphinx/tree_envs.rst
@@ -184,3 +184,12 @@ This is the configuration for IPL-3
    :title: ipl-3
    :remove-sasbase:
 
+IPL-4
+-----
+
+This is the configuration for IPL-4
+
+.. datamodel:: tree.tree:Tree
+   :prog: ipl-4
+   :title: ipl-4
+   :remove-sasbase:


### PR DESCRIPTION
Hi @havok2063 Can you check that I added a stub for IPL-4 to tree correctly, with no changes expected from IPL-3 (either env vars or paths), since IPL-4 has the same structure as IPL-3 except more data including additional MJDs after summer shutdown, and data from LCO -- neither of which are included in the IPL-3 DR19 candidate.  Details available at http://wiki.sdss.org/display/IPL/IPL-4