### PR TITLE
remove "component" from astra file names

### DIFF
--- a/data/ipl3.cfg
+++ b/data/ipl3.cfg
@@ -163,8 +163,8 @@ spAllLineField_epoch = $BOSS_SPECTRO_REDUX/{run2d}/epoch/spectra/full/@pad_field
 # Astra paths
 
 # Astra per-spectrum files
-mwmStar = $MWM_ASTRA/{v_astra}/spectra/star/@sdss_id_groups|/mwmStar-{v_astra}-{sdss_id}@component_default|.fits
-mwmVisit = $MWM_ASTRA/{v_astra}/spectra/visit/@sdss_id_groups|/mwmVisit-{v_astra}-{sdss_id}@component_default|.fits
+mwmStar = $MWM_ASTRA/{v_astra}/spectra/star/@sdss_id_groups|/mwmStar-{v_astra}-{sdss_id}.fits
+mwmVisit = $MWM_ASTRA/{v_astra}/spectra/visit/@sdss_id_groups|/mwmVisit-{v_astra}-{sdss_id}.fits
 
 # Astra target summary files
 mwmTargets = $MWM_ASTRA/{v_astra}/summary/mwmTargets-{v_astra}.fits
@@ -174,20 +174,20 @@ mwmAllStar = $MWM_ASTRA/{v_astra}/summary/mwmAllStar-{v_astra}.fits
 mwmAllVisit = $MWM_ASTRA/{v_astra}/summary/mwmAllVisit-{v_astra}.fits
 
 # Astra per-spectrum pipeline output files
-astraStarASPCAP = $MWM_ASTRA/{v_astra}/results/star/@sdss_id_groups|/astraStarASPCAP-{v_astra}-{sdss_id}@component_default|.fits
-astraVisitASPCAP = $MWM_ASTRA/{v_astra}/results/visit/@sdss_id_groups|/astraVisitASPCAP-{v_astra}-{sdss_id}@component_default|.fits
-astraStarAstroNN = $MWM_ASTRA/{v_astra}/results/star/@sdss_id_groups|/astraStarAstroNN-{v_astra}-{sdss_id}@component_default|.fits
-astraVisitAstroNN = $MWM_ASTRA/{v_astra}/results/visit/@sdss_id_groups|/astraVisitAstroNN-{v_astra}-{sdss_id}@component_default|.fits
-astraStarTheCannon = $MWM_ASTRA/{v_astra}/results/star/@sdss_id_groups|/astraStarTheCannon-{v_astra}-{sdss_id}@component_default|.fits
-astraVisitTheCannon = $MWM_ASTRA/{v_astra}/results/visit/@sdss_id_groups|/astraVisitTheCannon-{v_astra}-{sdss_id}@component_default|.fits
-astraStarCorv = $MWM_ASTRA/{v_astra}/results/star/@sdss_id_groups|/astraStarCorv-{v_astra}-{sdss_id}@component_default|.fits
-astraVisitCorv = $MWM_ASTRA/{v_astra}/results/visit/@sdss_id_groups|/astraVisitCorv-{v_astra}-{sdss_id}@component_default|.fits
-astraStarThePayne = $MWM_ASTRA/{v_astra}/results/star/@sdss_id_groups|/astraStarThePayne-{v_astra}-{sdss_id}@component_default|.fits
-astraVisitThePayne = $MWM_ASTRA/{v_astra}/results/visit/@sdss_id_groups|/astraVisitThePayne-{v_astra}-{sdss_id}@component_default|.fits
-astraStarSLAM = $MWM_ASTRA/{v_astra}/results/star/@sdss_id_groups|/astraStarSLAM-{v_astra}-{sdss_id}@component_default|.fits
-astraVisitSLAM = $MWM_ASTRA/{v_astra}/results/visit/@sdss_id_groups|/astraVisitSLAM-{v_astra}-{sdss_id}@component_default|.fits
-astraStarSnowWhite = $MWM_ASTRA/{v_astra}/results/star/@sdss_id_groups|/astraStarSnowWhite-{v_astra}-{sdss_id}@component_default|.fits
-astraVisitSnowWhite = $MWM_ASTRA/{v_astra}/results/visit/@sdss_id_groups|/astraVisitSnowWhite-{v_astra}-{sdss_id}@component_default|.fits
+astraStarASPCAP = $MWM_ASTRA/{v_astra}/results/star/@sdss_id_groups|/astraStarASPCAP-{v_astra}-{sdss_id}.fits
+astraVisitASPCAP = $MWM_ASTRA/{v_astra}/results/visit/@sdss_id_groups|/astraVisitASPCAP-{v_astra}-{sdss_id}.fits
+astraStarAstroNN = $MWM_ASTRA/{v_astra}/results/star/@sdss_id_groups|/astraStarAstroNN-{v_astra}-{sdss_id}.fits
+astraVisitAstroNN = $MWM_ASTRA/{v_astra}/results/visit/@sdss_id_groups|/astraVisitAstroNN-{v_astra}-{sdss_id}.fits
+astraStarTheCannon = $MWM_ASTRA/{v_astra}/results/star/@sdss_id_groups|/astraStarTheCannon-{v_astra}-{sdss_id}.fits
+astraVisitTheCannon = $MWM_ASTRA/{v_astra}/results/visit/@sdss_id_groups|/astraVisitTheCannon-{v_astra}-{sdss_id}.fits
+astraStarCorv = $MWM_ASTRA/{v_astra}/results/star/@sdss_id_groups|/astraStarCorv-{v_astra}-{sdss_id}.fits
+astraVisitCorv = $MWM_ASTRA/{v_astra}/results/visit/@sdss_id_groups|/astraVisitCorv-{v_astra}-{sdss_id}.fits
+astraStarThePayne = $MWM_ASTRA/{v_astra}/results/star/@sdss_id_groups|/astraStarThePayne-{v_astra}-{sdss_id}.fits
+astraVisitThePayne = $MWM_ASTRA/{v_astra}/results/visit/@sdss_id_groups|/astraVisitThePayne-{v_astra}-{sdss_id}.fits
+astraStarSLAM = $MWM_ASTRA/{v_astra}/results/star/@sdss_id_groups|/astraStarSLAM-{v_astra}-{sdss_id}.fits
+astraVisitSLAM = $MWM_ASTRA/{v_astra}/results/visit/@sdss_id_groups|/astraVisitSLAM-{v_astra}-{sdss_id}.fits
+astraStarSnowWhite = $MWM_ASTRA/{v_astra}/results/star/@sdss_id_groups|/astraStarSnowWhite-{v_astra}-{sdss_id}.fits
+astraVisitSnowWhite = $MWM_ASTRA/{v_astra}/results/visit/@sdss_id_groups|/astraVisitSnowWhite-{v_astra}-{sdss_id}.fits
 
 # Astra pipeline summary files
 astraAllStarBest = $MWM_ASTRA/{v_astra}/summary/astraAllStarBest-{v_astra}.fits

--- a/data/sdsswork.cfg
+++ b/data/sdsswork.cfg
@@ -335,8 +335,8 @@ confSummaryF_test = $SDSSCORE_DIR/{obs}/summary_files/@configsubmodule|/@configg
 # Astra paths
 
 # Astra per-spectrum files
-mwmStar = $MWM_ASTRA/{v_astra}/spectra/star/@sdss_id_groups|/mwmStar-{v_astra}-{sdss_id}@component_default|.fits
-mwmVisit = $MWM_ASTRA/{v_astra}/spectra/visit/@sdss_id_groups|/mwmVisit-{v_astra}-{sdss_id}@component_default|.fits
+mwmStar = $MWM_ASTRA/{v_astra}/spectra/star/@sdss_id_groups|/mwmStar-{v_astra}-{sdss_id}.fits
+mwmVisit = $MWM_ASTRA/{v_astra}/spectra/visit/@sdss_id_groups|/mwmVisit-{v_astra}-{sdss_id}.fits
 
 # Astra target summary files
 mwmTargets = $MWM_ASTRA/{v_astra}/summary/mwmTargets-{v_astra}.fits
@@ -346,20 +346,20 @@ mwmAllStar = $MWM_ASTRA/{v_astra}/summary/mwmAllStar-{v_astra}.fits
 mwmAllVisit = $MWM_ASTRA/{v_astra}/summary/mwmAllVisit-{v_astra}.fits
 
 # Astra per-spectrum pipeline output files
-astraStarASPCAP = $MWM_ASTRA/{v_astra}/results/star/@sdss_id_groups|/astraStarASPCAP-{v_astra}-{sdss_id}@component_default|.fits
-astraVisitASPCAP = $MWM_ASTRA/{v_astra}/results/visit/@sdss_id_groups|/astraVisitASPCAP-{v_astra}-{sdss_id}@component_default|.fits
-astraStarAstroNN = $MWM_ASTRA/{v_astra}/results/star/@sdss_id_groups|/astraStarAstroNN-{v_astra}-{sdss_id}@component_default|.fits
-astraVisitAstroNN = $MWM_ASTRA/{v_astra}/results/visit/@sdss_id_groups|/astraVisitAstroNN-{v_astra}-{sdss_id}@component_default|.fits
-astraStarTheCannon = $MWM_ASTRA/{v_astra}/results/star/@sdss_id_groups|/astraStarTheCannon-{v_astra}-{sdss_id}@component_default|.fits
-astraVisitTheCannon = $MWM_ASTRA/{v_astra}/results/visit/@sdss_id_groups|/astraVisitTheCannon-{v_astra}-{sdss_id}@component_default|.fits
-astraStarCorv = $MWM_ASTRA/{v_astra}/results/star/@sdss_id_groups|/astraStarCorv-{v_astra}-{sdss_id}@component_default|.fits
-astraVisitCorv = $MWM_ASTRA/{v_astra}/results/visit/@sdss_id_groups|/astraVisitCorv-{v_astra}-{sdss_id}@component_default|.fits
-astraStarThePayne = $MWM_ASTRA/{v_astra}/results/star/@sdss_id_groups|/astraStarThePayne-{v_astra}-{sdss_id}@component_default|.fits
-astraVisitThePayne = $MWM_ASTRA/{v_astra}/results/visit/@sdss_id_groups|/astraVisitThePayne-{v_astra}-{sdss_id}@component_default|.fits
-astraStarSLAM = $MWM_ASTRA/{v_astra}/results/star/@sdss_id_groups|/astraStarSLAM-{v_astra}-{sdss_id}@component_default|.fits
-astraVisitSLAM = $MWM_ASTRA/{v_astra}/results/visit/@sdss_id_groups|/astraVisitSLAM-{v_astra}-{sdss_id}@component_default|.fits
-astraStarSnowWhite = $MWM_ASTRA/{v_astra}/results/star/@sdss_id_groups|/astraStarSnowWhite-{v_astra}-{sdss_id}@component_default|.fits
-astraVisitSnowWhite = $MWM_ASTRA/{v_astra}/results/visit/@sdss_id_groups|/astraVisitSnowWhite-{v_astra}-{sdss_id}@component_default|.fits
+astraStarASPCAP = $MWM_ASTRA/{v_astra}/results/star/@sdss_id_groups|/astraStarASPCAP-{v_astra}-{sdss_id}.fits
+astraVisitASPCAP = $MWM_ASTRA/{v_astra}/results/visit/@sdss_id_groups|/astraVisitASPCAP-{v_astra}-{sdss_id}.fits
+astraStarAstroNN = $MWM_ASTRA/{v_astra}/results/star/@sdss_id_groups|/astraStarAstroNN-{v_astra}-{sdss_id}.fits
+astraVisitAstroNN = $MWM_ASTRA/{v_astra}/results/visit/@sdss_id_groups|/astraVisitAstroNN-{v_astra}-{sdss_id}.fits
+astraStarTheCannon = $MWM_ASTRA/{v_astra}/results/star/@sdss_id_groups|/astraStarTheCannon-{v_astra}-{sdss_id}.fits
+astraVisitTheCannon = $MWM_ASTRA/{v_astra}/results/visit/@sdss_id_groups|/astraVisitTheCannon-{v_astra}-{sdss_id}.fits
+astraStarCorv = $MWM_ASTRA/{v_astra}/results/star/@sdss_id_groups|/astraStarCorv-{v_astra}-{sdss_id}.fits
+astraVisitCorv = $MWM_ASTRA/{v_astra}/results/visit/@sdss_id_groups|/astraVisitCorv-{v_astra}-{sdss_id}.fits
+astraStarThePayne = $MWM_ASTRA/{v_astra}/results/star/@sdss_id_groups|/astraStarThePayne-{v_astra}-{sdss_id}.fits
+astraVisitThePayne = $MWM_ASTRA/{v_astra}/results/visit/@sdss_id_groups|/astraVisitThePayne-{v_astra}-{sdss_id}.fits
+astraStarSLAM = $MWM_ASTRA/{v_astra}/results/star/@sdss_id_groups|/astraStarSLAM-{v_astra}-{sdss_id}.fits
+astraVisitSLAM = $MWM_ASTRA/{v_astra}/results/visit/@sdss_id_groups|/astraVisitSLAM-{v_astra}-{sdss_id}.fits
+astraStarSnowWhite = $MWM_ASTRA/{v_astra}/results/star/@sdss_id_groups|/astraStarSnowWhite-{v_astra}-{sdss_id}.fits
+astraVisitSnowWhite = $MWM_ASTRA/{v_astra}/results/visit/@sdss_id_groups|/astraVisitSnowWhite-{v_astra}-{sdss_id}.fits
 
 # Astra pipeline summary files
 astraAllStarBest = $MWM_ASTRA/{v_astra}/summary/astraAllStarBest-{v_astra}.fits

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,7 +72,7 @@ dev =
 	wheel>=0.33.6
 
 docs =
-	Sphinx>=7.2.0
+	Sphinx>=7.2.0,<7.3
 	sphinx_bootstrap_theme>=0.4.12
 	recommonmark>=0.6
 	sphinx-argparse>=0.2.5


### PR DESCRIPTION
The removes the unused "component" flag from the astra filenames in IPL3.