### PR TITLE
Added paths for guider and FVC images

### DIFF
--- a/data/ipl3.cfg
+++ b/data/ipl3.cfg
@@ -222,6 +222,15 @@ astraAllStarSnowWhite = $MWM_ASTRA/{v_astra}/summary/astraAllStarSnowWhite-{v_as
 astraAllVisitSnowWhite = $MWM_ASTRA/{v_astra}/summary/astraAllVisitSnowWhite-{v_astra}.fits
 
 # VAC paths
-# SDSS-V VAC 0003 
+# SDSS-V VAC 0003
 apogee_distmass = $APOGEE_DISTMASS/APOGEE_IPL3_DistMass_{vers}.fits
 
+# Guider and FVC image paths
+gimg_apo = $GCAM_DATA_N/{mjd}/gimg-gfa{camnum:d}n-{expnum:0>4}.fits
+gimg_lco = $GCAM_DATA_S/{mjd}/gimg-gfa{camnum:d}s-{expnum:0>4}.fits
+proc_gimg_apo = $GCAM_DATA_N/{mjd}/proc-gimg-gfa{camnum:d}n-{expnum:0>4}.fits
+proc_gimg_lco = $GCAM_DATA_S/{mjd}/proc-gimg-gfa{camnum:d}s-{expnum:0>4}.fits
+fimg_apo = $FCAM_DATA_N/{mjd}/fimg-fvc{camnum:d}n-{expnum:0>4}.fits
+fimg_lco = $FCAM_DATA_S/{mjd}/fimg-fvc{camnum:d}s-{expnum:0>4}.fits
+proc_fimg_apo = $FCAM_DATA_N/{mjd}/proc-fimg-fvc{camnum:d}n-{expnum:0>4}.fits
+proc_fimg_lco = $FCAM_DATA_S/{mjd}/proc-fimg-fvc{camnum:d}s-{expnum:0>4}.fits

--- a/data/sdsswork.cfg
+++ b/data/sdsswork.cfg
@@ -493,10 +493,18 @@ lvm_agcam_coadd_guiderdata = $AGCAM_DATA_S/{mjd}/coadds/lvm.{tel}.coadd_s{specfr
 lvm_agcam_coadd_sources = $AGCAM_DATA_S/{mjd}/coadds/lvm.{tel}.coadd_s{specframe:0>8}_sources.parquet
 
 # VAC paths
-# SDSS-V VAC 0003 
+# SDSS-V VAC 0003
 apogee_distmass = $APOGEE_DISTMASS/{vers}/APOGEE_IPL3_DistMass_{vers}.fits
 
 # HIPS paths
 sdss_moc = $SDSS_HIPS/{release}/{survey}/Moc.{ext}
 
-
+# Guider and FVC image paths
+gimg_apo = $GCAM_DATA_N/{mjd}/gimg-gfa{camnum:d}n-{expnum:0>4}.fits
+gimg_lco = $GCAM_DATA_S/{mjd}/gimg-gfa{camnum:d}s-{expnum:0>4}.fits
+proc_gimg_apo = $GCAM_DATA_N/{mjd}/proc-gimg-gfa{camnum:d}n-{expnum:0>4}.fits
+proc_gimg_lco = $GCAM_DATA_S/{mjd}/proc-gimg-gfa{camnum:d}s-{expnum:0>4}.fits
+fimg_apo = $FCAM_DATA_N/{mjd}/fimg-fvc{camnum:d}n-{expnum:0>4}.fits
+fimg_lco = $FCAM_DATA_S/{mjd}/fimg-fvc{camnum:d}s-{expnum:0>4}.fits
+proc_fimg_apo = $FCAM_DATA_N/{mjd}/proc-fimg-fvc{camnum:d}n-{expnum:0>4}.fits
+proc_fimg_lco = $FCAM_DATA_S/{mjd}/proc-fimg-fvc{camnum:d}s-{expnum:0>4}.fits


### PR DESCRIPTION
Adds paths for `gimg`, `proc_gimg`, `fimg`, and `proc_fimg` for APO and LCO.