### PR TITLE
Make confSummary_test default

### DIFF
--- a/data/sdsswork.cfg
+++ b/data/sdsswork.cfg
@@ -338,8 +338,8 @@ spAllLineField_epoch = $BOSS_SPECTRO_REDUX/{run2d}/epoch/spectra/full/@pad_field
 #
 # github products
 #
-confSummary = $SDSSCORE_DIR/{obs}/summary_files/@configgrp|/confSummary-{configid}.par
-confSummaryF = $SDSSCORE_DIR/{obs}/summary_files/@configgrp|/confSummaryF-{configid}.par
+confSummary = $SDSSCORE_DIR/{obs}/summary_files/@configsubmodule|/@configgrp|/confSummary-{configid}.par
+confSummaryF = $SDSSCORE_DIR/{obs}/summary_files/@configsubmodule|/@configgrp|/confSummaryF-{configid}.par
 confSummary_test = $SDSSCORE_DIR/{obs}/summary_files/@configsubmodule|/@configgrp|/confSummary-{configid}.par
 confSummaryF_test = $SDSSCORE_DIR/{obs}/summary_files/@configsubmodule|/@configgrp|/confSummaryF-{configid}.par
 


### PR DESCRIPTION
Replaces the definition for `confSummary` and `confSummaryF` with the same one as for `confSummary(F)_test` (i.e., with the thousands grouping in addition to the hundreds one).

For now we are keeping the definitions for `confSummary(F)_test`, which are now identical to the ones for `confSummary(F)`.