### PR TITLE
Removes deprecated distutils

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,18 @@ Change Log
 
 This document records the main changes to the tree code.
 
+4.0.8 (unreleased)
+------------------
+- Removed use of deprecated `distutils`
+
+4.0.7 (12-04-2024)
+------------------
+- Added new paths for guider and fvc images
+- Added confSummary paths
+- Updates to dr19 config
+- Removed component field from astra paths
+- Updated apogee paths for darks/flats to remove "corr" field
+
 4.0.6 (03-08-2024)
 ------------------
 - Initial IPL-4 config

--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,11 @@
 #
 
 
-import distutils.dir_util
+import shutil
 from setuptools import setup
 
 # Copy data files into the python/tree/data directory
-tmp = distutils.dir_util.copy_tree('data', 'python/tree/data')
+tmp = shutil.copytree('data', 'python/tree/data', dirs_exist_ok=True)
 
 
 setup()
-


### PR DESCRIPTION
This PR closes #102 and removes the deprecated `distutils` package, replacing with a `shutil` copy.  