### PR TITLE
allspec for ipl3 and vac cleanup

### DIFF
--- a/data/dr19.cfg
+++ b/data/dr19.cfg
@@ -24,21 +24,22 @@ GCAM_DATA_N = %(DATA_ROOT)s/gcam/apo
 ALLSPEC = %(SPECTRO_ROOT)s/allspec
 APOGEE_REDUX = %(SPECTRO_ROOT)s/apogee/redux
 LVM_SPECTRO_REDUX = %(SPECTRO_ROOT)s/lvm/redux
+MWM_ASTRA = %(SPECTRO_ROOT)s/astra
 #
 #
 #
 [VAC]
-APMADGICS= %(VAC_ROOT)s//mwm/apMADGICS
-APOGEE_OCCAM= %(VAC_ROOT)s//mwm/apogee-occam
-APOGEE_STARHORSE= %(VAC_ROOT)s//mwm/apogee-starhorse
-BHM_QSOPROP= %(VAC_ROOT)s//bhm/qso-properties
-DL1_SDSS_EROSITA= %(VAC_ROOT)s//mos/DL1_SDSS_eROSITA
-MWM_MDWARF= %(VAC_ROOT)s//mwm/m-dwarf
-MWM_MINESWEEPER= %(VAC_ROOT)s//mwm/minesweeper
-MWM_SSPP= %(VAC_ROOT)s/mwm/sspp
-MWM_STARFLOW= %(VAC_ROOT)s//mwm/starflow
-MWM_WHITEDWARF= %(VAC_ROOT)s//mwm/white-dwarf
-SPIDERS_AGN= %(VAC_ROOT)s//bhm/spiders-agn
+APMADGICS = %(VAC_ROOT)s/mwm/apMADGICS
+APOGEE_OCCAM = %(VAC_ROOT)s/mwm/apogee-occam
+APOGEE_STARHORSE = %(VAC_ROOT)s/mwm/apogee-starhorse
+BHM_QSOPROP = %(VAC_ROOT)s/bhm/qso-properties
+DL1_SDSS_EROSITA = %(VAC_ROOT)s/mos/DL1_SDSS_eROSITA
+MWM_MDWARF = %(VAC_ROOT)s/mwm/m-dwarf
+MWM_MINESWEEPER = %(VAC_ROOT)s/mwm/minesweeper
+MWM_SSPP = %(VAC_ROOT)s/mwm/sspp
+MWM_STARFLOW = %(VAC_ROOT)s/mwm/starflow
+MWM_WHITEDWARF = %(VAC_ROOT)s/mwm/white-dwarf
+SPIDERS_AGN = %(VAC_ROOT)s/bhm/spiders-agn
 #
 #
 #
@@ -270,17 +271,11 @@ eSDSS_DA_df = $MWM_WHITEDWARF/da_white_dwarf_properties/{vers}/eSDSS_DA_df.fits
 # SDSS-V VAC 0009
 # DR19Q_prop = $BHM_QSOPROP/{vers}/DR19Q_prop-{run2d}.fits
 #
-# SDSS-V VAC 0010
-# SPIDERS_eROSITA_SDSS_OpticalFit = $SPIDERS_AGN/{vers}/SPIDERS_eROSITA_SDSS_OpticalFit-{vers}.fits (Pending April 15  )
-#
 # SDSS-V VAC 0011
 mdwarf_abundances = $MWM_MDWARF/elemental_abundances/mdwarf_abundances-{vers}.fits
 #
 # SDSS-V VAC 0014
 apogee_starhorse = $APOGEE_STARHORSE/APOGEE_DR19_DR3_STARHORSE_{vers}.fits
-#
-# SDSS-V VAC 0015
-# snowWhiteTBD = $MWM_WHITEDWARF/{vers}/snowWhiteTBD-{vers}.fits (Pending April 15  )
 #
 # SDSS-V VAC 0017
 apogee_occam_member = $APOGEE_OCCAM/occam_member-{vers}.fits

--- a/data/ipl3.cfg
+++ b/data/ipl3.cfg
@@ -29,6 +29,7 @@ GCAM_DATA_N = %(DATA_ROOT)s/gcam/apo
 [SPECTRO]
 name = ipl-3
 SPECTRO_ROOT = %(FILESYSTEM)s/%(name)s/spectro
+ALLSPEC = %(SPECTRO_ROOT)s/allspec
 APOGEE_REDUX = %(SPECTRO_ROOT)s/apogee/redux
 BOSS_SPECTRO_REDUX = %(SPECTRO_ROOT)s/boss/redux
 LVM_SPECTRO_REDUX = %(SPECTRO_ROOT)s/lvm/redux
@@ -268,6 +269,10 @@ fimg_apo = $FCAM_DATA_N/{mjd}/fimg-fvc{camnum:d}n-{expnum:0>4}.fits
 proc_fimg_apo = $FCAM_DATA_N/{mjd}/proc-fimg-fvc{camnum:d}n-{expnum:0>4}.fits
 #proc_fimg_lco = $FCAM_DATA_S/{mjd}/proc-fimg-fvc{camnum:d}s-{expnum:0>4}.fits
 
+# ALLSPEC paths for IPL3
+allspec = $ALLSPEC/{vers}/allspec-{release}-{vers}.fits
+multiplex = $ALLSPEC/{vers}/multiplex-{release}-{vers}.fits
+
 # VAC paths for IPL3
 #
 # SDSS-V VAC 0003
@@ -295,19 +300,16 @@ SDSSV_DA_df = $MWM_WHITEDWARF/da_white_dwarf_properties/{vers}/eSDSS_DA_df.fits
 eSDSS_DA_df = $MWM_WHITEDWARF/da_white_dwarf_properties/{vers}/eSDSS_DA_df.fits
 #
 # SDSS-V VAC 0009
-# DR19Q_prop = $BHM_QSOFIT/{vers}/DR19Q_prop-{vers}.fits (Pending April 15)
-#
-# SDSS-V VAC 0010
-# SPIDERS_eROSITA_SDSS_OpticalFit = $SPIDERS_AGN/{vers}/SPIDERS_eROSITA_SDSS_OpticalFit-{vers}.fits (Pending April 15)
+# DR19Q_prop = $BHM_QSOPROP/{vers}/DR19Q_prop-{run2d}.fits
 #
 # SDSS-V VAC 0011
 mdwarf_abundances = $MWM_MDWARF/elemental_abundances/mdwarf_abundances-{vers}.fits
 #
 # SDSS-V VAC 0014
-# starhorseTBD = $MWM_STARHORSE/{vers}/starhorseTBD-{vers}.fits (Pending April 15)
+apogee_starhorse = $APOGEE_STARHORSE/APOGEE_DR19_DR3_STARHORSE_{vers}.fits
 #
 # SDSS-V VAC 0015
-# snowWhiteTBD = $MWM_WHITEDWARF/{vers}/snowWhiteTBD-{vers}.fits (Pending April 15)
+# snowWhiteTBD = $MWM_WHITEDWARF/{vers}/snowWhiteTBD-{vers}.fits (Pending April 15  )
 #
 # SDSS-V VAC 0017
 apogee_occam_member = $APOGEE_OCCAM/occam_member-{vers}.fits


### PR DESCRIPTION
Hi @havok2063,

@AMWeijmans  is trying to test sdss-access for the allspec file, and I noticed it was added to dr19.cfg already but not ipl3, so I added it, and cleaned up some vac entries.

Would you please have a look at this  PR; and do the merge?

In addition, once this PR for tree is merged, could you please tag both tree and sdss-access, which was last done in April, so that https://sdss-access.readthedocs.io/en/latest/paths.html is updated with these latest changes for DR19/IPL3?

Cheers,
Joel 