### PR TITLE
build changes; tag and version bump

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.0.9
+current_version = 4.0.10dev
 commit = True
 tag = False
 tag_name = {new_version}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.0.9dev
+current_version = 4.0.9
 commit = True
 tag = False
 tag_name = {new_version}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        python bin/copy_data.py
         pip install .[dev]
 
     - name: Lint with flake8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ jobs:
 
             - name: Build package
               run: |
+                python bin/copy_data.py
                 python -m build
 
             - name: Publish to PyPI

--- a/.github/workflows/sphinxbuild.yml
+++ b/.github/workflows/sphinxbuild.yml
@@ -27,4 +27,4 @@ jobs:
         # The command used to build your documentation.
         build-command: make html  # optional, default is make html
         # Pre-build command
-        pre-build-command: "apt-get update -y && apt-get install -y gcc && pip install .[docs]"
+        pre-build-command: "apt-get update -y && apt-get install -y gcc && python bin/copy_data.py && pip install .[docs]"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,11 +6,12 @@ Change Log
 
 This document records the main changes to the tree code.
 
-4.0.9 (unreleased)
+4.0.9 (06-18-2025)
 ------------------
 - Updating paths for DR19: apogee, astra, vacs, etc
+- Basic project maintenance
 
-4.0.8 (04-16-2024)
+4.0.8 (04-16-2025)
 ------------------
 - Removed use of deprecated `distutils`
 - Updated github actions

--- a/README.md
+++ b/README.md
@@ -20,8 +20,11 @@ To install tree for development locally:
 ```
 git clone https://github.com/sdss/tree
 cd tree
+python bin/copy_data.py
 pip install -e ".[dev,docs]"
 ```
+
+`python bin/copy_data.py` must be run ahead of any package install or builds with `python -m build` to ensure the config files are properly in place.
 
 ### Install at Utah
 
@@ -71,6 +74,3 @@ New tag names follow the Python semantic versioning syntax, i.e. `X.Y.Z`.
 - GitHub: https://github.com/sdss/tree
 - Documentation: https://sdss-tree.readthedocs.org
 - Issues: https://github.com/sdss/tree/issues
-
-
-

--- a/bin/copy_data.py
+++ b/bin/copy_data.py
@@ -1,0 +1,8 @@
+# !usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+
+import shutil
+
+# Copy data files into the python/tree/data directory
+tmp = shutil.copytree('data', 'python/tree/data', dirs_exist_ok=True)

--- a/python/tree/tree.py
+++ b/python/tree/tree.py
@@ -15,7 +15,6 @@ import sys
 import glob
 import re
 from collections import OrderedDict
-import six
 import json
 import datetime
 from tree import log, config as cfg_params
@@ -220,7 +219,7 @@ class Tree(object):
         # check initial argument
         cfgname = (config or self.config_name)
         cfgname = 'sdsswork' if cfgname is None else cfgname
-        assert isinstance(cfgname, six.string_types), 'config name must be a string'
+        assert isinstance(cfgname, str), 'config name must be a string'
         cfgname = cfgname.lower()
 
         config_name = cfgname if cfgname.endswith('.cfg') else '{0}.cfg'.format(cfgname)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = sdss-tree
-version = 4.0.9
+version = 4.0.10dev
 author = Brian Cherinka
 author_email = bcherinka@stsci.edu
 description = Control and setup of SDSS tree environment and modules

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = sdss-tree
-version = 4.0.9dev
+version = 4.0.9
 author = Brian Cherinka
 author_email = bcherinka@stsci.edu
 description = Control and setup of SDSS tree environment and modules

--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,7 @@
 #
 
 
-import shutil
 from setuptools import setup
-
-# Copy data files into the python/tree/data directory
-tmp = shutil.copytree('data', 'python/tree/data', dirs_exist_ok=True)
 
 
 setup()


### PR DESCRIPTION
Tag and version bump.  Also moves the shutil copy data command from `setup.py` to a new script file, to future proof against new python builds.  The `data/` directory copy does not happen automatically but can be run with `python bin/copy_data.py` before running `pip install`.   This change will allow to move towards a full `pyproject.toml` replacement of `setup.cfg` in the future.  